### PR TITLE
Doublon d'information concernant les liens vers projet

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -57,10 +57,7 @@
 
 						«Concerto» est une expérience menée par une bande de scientifiques mélomanes. Ceux-ci, incapable de jouer le moindre instrument, ont créé un groupe de musique nommé «Allo Machines», composé exclusivement de robots. Pour réaliser leur rêve de former un «band», les chercheurs organisent donc le concert expérimental «Concerto». Ils invitent donc les spectateurs à contrôler eux-mêmes les androïdes musiciens pour leur enseigner l'art de la musique à travers leurs compositions musicales expérimentales.
 					</p>
-					<h3>Dates de diffusion :</h3>
-					<p>20, 21 et 22 mars 2020, 20h.</p>
-					<h3>Lien pour assister au projet :</h3>
-					<a href="experience/index.html" target="_blank">experience/index.html</a>
+					<br>
 					<h3>Réalisé par :</h3>
 					<ul class="photos_finissants">
 						<li><img src="../../../medias/concerto/emile.jpg" alt="Emile"> Émile Désilets</li>
@@ -71,6 +68,7 @@
 					
 				</div>
 			</div>
+			
 			<div class="galerie_projet">
 				<h3>Galerie d'images :</h3>
 				


### PR DESCRIPTION
Suppression de doublon d'information concernant les liens vers projet.